### PR TITLE
Use Github Actions for CI and publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - head
+    continue-on-error: ${{ matrix.ruby == 'head' }}
+    name: Ruby ${{ matrix.ruby }}
+    services:
+      postgres:
+        image: redis
+        ports:
+          - 6379:6379
+      memcached:
+        image: memcached
+        ports:
+          - 11211:11211
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rake

--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -1,0 +1,22 @@
+name: Gem
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+    - name: Build
+      run: |
+        gem build *.gemspec
+    - name: Publish to RubyGems
+      run: |
+        gem push --verbose *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_TOKEN}}


### PR DESCRIPTION
This library hasn't had a release in over 3 years.

I would like to publish a new one so we can stop pulling from git. Setting up boilerplate publishing automation, so new releases on Github will trigger pushes to Rubygems. Requires `RUBYGEMS_TOKEN` be available as a secret in either the repo or your personal account.

Also sets up CI because might as well.